### PR TITLE
feat: Define PersistentModel and ValueObject Mapper

### DIFF
--- a/Projects/Features/Diary/Transformer/DialogueValueTransformer.swift
+++ b/Projects/Features/Diary/Transformer/DialogueValueTransformer.swift
@@ -1,0 +1,31 @@
+import Foundation
+import Persistence
+
+public final class DialogueValueTransformer: ValueTransformer {
+    internal static let name = NSValueTransformerName(rawValue: "DialogueValueTransformer")
+    
+    // From Dialogue to DialogueModel
+    public override class func transformedValueClass() -> AnyClass {
+        return DialogueModel.self
+    }
+    
+    // Perform the transformation from Dialogue to DialogueModel
+    public override func transformedValue(_ value: Any?) -> Any? {
+        guard let dialogue = value as? Dialogue else { return nil }
+        return DialogueModel(
+            content: dialogue.content,
+            createAt: dialogue.createdAt,
+            role: dialogue.role
+        )
+    }
+    
+    // Perform the reverse transformation from DialogueModel to Dialogue
+    public override func reverseTransformedValue(_ value: Any?) -> Any? {
+        guard let dialogueModel = value as? DialogueModel else { return nil }
+        return Dialogue(
+            content: dialogueModel.content,
+            createdAt: dialogueModel.createAt,
+            role: dialogueModel.role
+        )
+    }
+}

--- a/Projects/Features/Diary/Transformer/DiaryTransformer.swift
+++ b/Projects/Features/Diary/Transformer/DiaryTransformer.swift
@@ -1,0 +1,74 @@
+import ComposableArchitecture
+import Foundation
+import SwiftData
+
+import Persistence
+
+internal protocol ValueMappable { }
+
+internal struct DiaryTransformer {
+    internal init(
+        entryTransformer: EntryValueTransformer = EntryValueTransformer(),
+        dialogueTransformer: DialogueValueTransformer = DialogueValueTransformer()
+    ) {
+        ValueTransformer
+            .setValueTransformer(
+                entryTransformer,
+                forName: EntryValueTransformer.name
+            )
+        ValueTransformer
+            .setValueTransformer(
+                dialogueTransformer,
+                forName: DialogueValueTransformer.name
+            )
+    }
+    
+    private var name: NSValueTransformerName? = nil
+    
+    internal mutating func configure<Value: ValueMappable>(for value: Value) throws {
+        if let value = value as? Entry {
+            self.name = EntryValueTransformer.name
+        }
+        if let value = value as? Dialogue {
+            self.name = DialogueValueTransformer.name
+        }
+        throw TransformerError.undefinedValueTransformer
+    }
+    
+    internal func map<Value: ValueMappable, Model: PersistentModel>(_ value: Value, to model: Model.Type) throws -> Model? {
+        guard let name = self.name else { throw TransformerError.transformerNameNotConfigured }
+        
+        let transformer = ValueTransformer(forName: name)
+        return transformer?.transformedValue(value) as? Model
+    }
+    
+    internal func map<Value: ValueMappable, Model: PersistentModel>(_ model: Model, to value: Value.Type) throws -> Value? {
+        guard let name = self.name else { throw TransformerError.transformerNameNotConfigured }
+        
+        let transformer = ValueTransformer(forName: name)
+        return transformer?.reverseTransformedValue(model) as? Value
+    }
+}
+
+extension DiaryTransformer {
+    internal enum TransformerError: Error {
+        case missingValueTransformer
+        case undefinedValueTransformer
+        case transformerNameNotConfigured
+    }
+}
+
+extension DependencyValues {
+    var transformer: DiaryTransformer {
+        get { self[DiaryTransformer.self] }
+        set { self[DiaryTransformer.self] = newValue }
+    }
+}
+
+extension DiaryTransformer: DependencyKey {
+    static var liveValue = DiaryTransformer()
+}
+
+extension DiaryTransformer: TestDependencyKey {
+    static var testValue = DiaryTransformer()
+}

--- a/Projects/Features/Diary/Transformer/EntryValueTransformer.swift
+++ b/Projects/Features/Diary/Transformer/EntryValueTransformer.swift
@@ -1,0 +1,31 @@
+import Foundation
+import Persistence
+
+public final class EntryValueTransformer: ValueTransformer {
+    internal static let name = NSValueTransformerName(rawValue: "EntryValueTransformer")
+    
+    // From Entry to EntryModel
+    public override class func transformedValueClass() -> AnyClass {
+        return EntryModel.self
+    }
+    
+    // Perform the transformation from Entry to EntryModel
+    public override func transformedValue(_ value: Any?) -> Any? {
+        guard let entry = value as? Entry else { return nil }
+        return EntryModel(
+            title: entry.title,
+            content: entry.content,
+            createdAt: entry.createdAt
+        )
+    }
+    
+    // Perform the reverse transformation from EntryModel to Entry
+    public override func reverseTransformedValue(_ value: Any?) -> Any? {
+        guard let entryModel = value as? EntryModel else { return nil }
+        return Entry(
+            title: entryModel.title,
+            content: entryModel.content,
+            createdAt: entryModel.createdAt
+        )
+    }
+}

--- a/Projects/Features/Diary/ValueObjects/Dialogue.swift
+++ b/Projects/Features/Diary/ValueObjects/Dialogue.swift
@@ -22,3 +22,5 @@ extension Dialogue {
         .init(content: "I see. You have been feeling heavy since this morning and have experienced something unpleasant. Anything good happen today?", createdAt: Date.now.addingTimeInterval(10000), role: .assistant)
     ]
 }
+
+extension Dialogue: ValueMappable { }

--- a/Projects/Features/Diary/ValueObjects/Entry.swift
+++ b/Projects/Features/Diary/ValueObjects/Entry.swift
@@ -66,3 +66,5 @@ extension Entry {
         )
     ]
 }
+
+extension Entry: ValueMappable { }


### PR DESCRIPTION
## Changes Made

- Implement type mapping for `EntryModel`, `DialogueModel` and it's respective value types `Entry`, `Dialogue`


## Background
- Store's `State` prefers its properties to be value types. 
- CRUD operations done inside `ModelActor`s should be propagated to `Store`s `State` for view updates.
- Type mapping is required from `PersistentModel` to value type usable in `State` and vice versa.

## Future Work
- `DiaryTransformer` should be defined in a separate package and be more abstract for use in other modules.
